### PR TITLE
Optional strings

### DIFF
--- a/Sources/Config/ConfigurationFile.swift
+++ b/Sources/Config/ConfigurationFile.swift
@@ -102,6 +102,8 @@ func parseNextProperty(properties: [String: Property], pair: (key: String, value
         switch typeHint {
         case .string, .url, .encrypted, .encryptionKey, .colour, .image, .regex:
             copy[pair.key] = ConfigurationProperty<String>(key: pair.key, typeHint: typeHintValue, dict: dict)
+        case .optionalString:
+            copy[pair.key] = ConfigurationProperty<String?>(key: pair.key, typeHint: typeHintValue, dict: dict)
         case .double, .float:
             copy[pair.key] = ConfigurationProperty<Double>(key: pair.key, typeHint: typeHintValue, dict: dict)
         case .int:

--- a/Sources/Config/ConfigurationProperty.swift
+++ b/Sources/Config/ConfigurationProperty.swift
@@ -29,6 +29,17 @@ struct ConfigurationProperty<T>: Property, AssociatedPropertyKeyProviding {
         }
     }
 
+    /// Returns `value` as the `ConfigurationProperty`'s value type (T).
+    /// If T is Optional<Something> and conversion of `value` fails,
+    /// rather than throwing an exception and bailing out this method
+    /// will return `Optional.none` using `ExpressibleByNilLiteral`'s
+    /// init(nilLiteral:), allowing a `ConfigurationProperty` with a nil
+    /// value.
+    ///
+    /// - Parameter value: The value to transform.
+    /// - Returns: The value as T, if possible.
+    /// - Throws: If the value is not convertible to T, Failure.notConvertible
+    ///   will be thrown.
     private static func transformValueToType(value: Any?) throws -> T {
         if let val = value as? T {
             return val

--- a/Sources/Config/ConfigurationProperty.swift
+++ b/Sources/Config/ConfigurationProperty.swift
@@ -54,11 +54,7 @@ struct ConfigurationProperty<T>: Property, AssociatedPropertyKeyProviding {
                 .flatMap { $0 as? [String: Any] }?
                 .mapValues { try ConfigurationProperty.transformValueToType(value: $0) }
 
-            if let overrides = overrides {
-                self.overrides = overrides
-            } else {
-                self.overrides = [:]
-            }
+            self.overrides = overrides ?? [:]
         } catch {
             return nil
         }

--- a/Tests/ConfigTests/ConfigurationPropertyTests.swift
+++ b/Tests/ConfigTests/ConfigurationPropertyTests.swift
@@ -229,7 +229,7 @@ class ConfigurationPropertyTests: XCTestCase {
     func testItCanWriteARegexProperty() throws {
         let imageProperty = ConfigurationProperty<String>(key: "test", typeHint: "Regex", dict: [
             "defaultValue": "an\\sexpression",
-            ])
+        ])
         let expectedValue = ##"    static let test: NSRegularExpression = try! NSRegularExpression(pattern: #"an\sexpression"#, options: [])"##
         let actualValue = try whenTheDeclarationIsWritten(for: imageProperty)
         expect(actualValue).to(equal(expectedValue))
@@ -238,8 +238,7 @@ class ConfigurationPropertyTests: XCTestCase {
     func testItCanWriteAnOptionalStringProperty() throws {
         let property = ConfigurationProperty<String?>(key: "test", typeHint: "String?", dict: [
             "defaultValue": NSNull.self
-            ])
-
+        ])
         let expectedValue = ##"    static let test: String? = nil"##
         let actualValue = try whenTheDeclarationIsWritten(for: property)
         expect(actualValue).to(equal(expectedValue))
@@ -251,8 +250,8 @@ class ConfigurationPropertyTests: XCTestCase {
             "overrides": [
                 "bla": NSNull.self
             ]
-            ])
-        let expectedValue = ##"    static let test: String? = nil"##
+        ])
+        let expectedValue = "    static let test: String? = nil"
         let actualValue = try whenTheDeclarationIsWritten(for: property, scheme: "bla")
         expect(actualValue).to(equal(expectedValue))
     }
@@ -260,8 +259,7 @@ class ConfigurationPropertyTests: XCTestCase {
     func testItCanWriteAnOptionalStringPropertyWithAValue() throws {
         let property = ConfigurationProperty<String?>(key: "test", typeHint: "String?", dict: [
             "defaultValue": "Test"
-            ])
-
+        ])
         let expectedValue = ##"    static let test: String? = #"Test"#"##
         let actualValue = try whenTheDeclarationIsWritten(for: property)
         expect(actualValue).to(equal(expectedValue))

--- a/Tests/ConfigTests/ConfigurationPropertyTests.swift
+++ b/Tests/ConfigTests/ConfigurationPropertyTests.swift
@@ -239,7 +239,7 @@ class ConfigurationPropertyTests: XCTestCase {
         let property = ConfigurationProperty<String?>(key: "test", typeHint: "String?", dict: [
             "defaultValue": NSNull.self
         ])
-        let expectedValue = ##"    static let test: String? = nil"##
+        let expectedValue = "    static let test: String? = nil"
         let actualValue = try whenTheDeclarationIsWritten(for: property)
         expect(actualValue).to(equal(expectedValue))
     }

--- a/Tests/ConfigTests/ConfigurationPropertyTests.swift
+++ b/Tests/ConfigTests/ConfigurationPropertyTests.swift
@@ -234,4 +234,36 @@ class ConfigurationPropertyTests: XCTestCase {
         let actualValue = try whenTheDeclarationIsWritten(for: imageProperty)
         expect(actualValue).to(equal(expectedValue))
     }
+
+    func testItCanWriteAnOptionalStringProperty() throws {
+        let property = ConfigurationProperty<String?>(key: "test", typeHint: "String?", dict: [
+            "defaultValue": NSNull.self
+            ])
+
+        let expectedValue = ##"    static let test: String? = nil"##
+        let actualValue = try whenTheDeclarationIsWritten(for: property)
+        expect(actualValue).to(equal(expectedValue))
+    }
+
+    func testItCanWriteAnOptionalOverrideStringProperty() throws {
+        let property = ConfigurationProperty<String?>(key: "test", typeHint: "String?", dict: [
+            "defaultValue": "Test",
+            "overrides": [
+                "bla": NSNull.self
+            ]
+            ])
+        let expectedValue = ##"    static let test: String? = nil"##
+        let actualValue = try whenTheDeclarationIsWritten(for: property, scheme: "bla")
+        expect(actualValue).to(equal(expectedValue))
+    }
+
+    func testItCanWriteAnOptionalStringPropertyWithAValue() throws {
+        let property = ConfigurationProperty<String?>(key: "test", typeHint: "String?", dict: [
+            "defaultValue": "Test"
+            ])
+
+        let expectedValue = ##"    static let test: String? = #"Test"#"##
+        let actualValue = try whenTheDeclarationIsWritten(for: property)
+        expect(actualValue).to(equal(expectedValue))
+    }
 }

--- a/Tests/ConfigTests/CustomTypeTests.swift
+++ b/Tests/ConfigTests/CustomTypeTests.swift
@@ -62,6 +62,12 @@ class CustomTypeTests: XCTestCase {
         expect(type?.placeholders.last?.name).to(equal("secondplaceholder"))
         expect(type?.placeholders.last?.type).to(equal(.bool))
     }
+
+    func testItCanParsePlaceholdersWithAnOptionalStringAsATypeAttribute() {
+        let type = CustomType(source: givenATypeDictionaryWithTypeAnnotations(firstPlaceholderType: "String?"))
+        expect(type?.placeholders.first?.name).to(equal("firstplaceholder"))
+        expect(type?.placeholders.first?.type).to(equal(.optionalString))
+    }
 }
 
 func givenATypeDictionary() -> [String: Any] {
@@ -71,9 +77,9 @@ func givenATypeDictionary() -> [String: Any] {
     ]
 }
 
-func givenATypeDictionaryWithTypeAnnotations() -> [String: Any] {
+func givenATypeDictionaryWithTypeAnnotations(firstPlaceholderType: String = "String", secondPlaceholderType: String = "Bool") -> [String: Any] {
     return [
         "typeName": "CustomType",
-        "initialiser": "CustomType(oneThing: {firstplaceholder:String}, secondThing: {secondplaceholder:Bool})"
+        "initialiser": "CustomType(oneThing: {firstplaceholder:\(firstPlaceholderType)}, secondThing: {secondplaceholder:\(secondPlaceholderType)})"
     ]
 }


### PR DESCRIPTION
Adds the definition of `String?` as `optionalString` to `PropertyType`, so we can construct optional strings as required.

Most of the heavy lifting happens in `ConfigurationProperty`, where previously we'd bail if converting the default value / overrides to `T` failed.

To detect whether conversion to `T` being nil isn't a failure, we check to see whether `T: ExpressibleByNilLiteral` (Optional is the only thing that conforms to this). If it is, we have to do a bit of a dance to do `T -> ExpressibleByNilLiteral -> T` so we can successfully initialise. The rest of it is relatively self-explanatory.