### PR TITLE
Use named configurations rather than schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ This is a command line tool for generating configuration files from a custom JSO
 Because each configuration requires a completely separate input file, it doesn't allow for sharing values across configurations, and it also makes it too easy to forget to add values across every configuration.
 
 ### How to use
-Simply pass a folder and a scheme name to the command:
+Simply pass a folder and a configuration name to the command:
 ```
-generateconfig --configPath /path/to/my/config --scheme my-scheme-name
+generateconfig --configPath /path/to/my/config --name my-config-name
 ```
 
 `generateconfig` will find all files with a `.config` file extension, search for a suitable template, and output a .swift file for each file.
@@ -26,19 +26,19 @@ A sample of the schema is:
   "key": {
     "description": "An optional comment to document the property. Will be added as a comment to the generated code",
     "type": "String",
-    "defaultValue": "value to be used by all schemes",
+    "defaultValue": "value to be used by all configurations",
     "overrides": {
-      "scheme pattern 1": "a different string to be used by schemes matching 'scheme pattern 1'",
-      "scheme pattern 2": "a different string to be used by schemes matching 'scheme pattern 2'"   
+      "config pattern 1": "a different string to be used by configurations matching 'config pattern 1'",
+      "config pattern 2": "a different string to be used by configurations matching 'config pattern 2'"
     }
   },
   "group: {
     "key": {
       "type": "String",
-      "defaultValue": "value to be used by all schemes",
+      "defaultValue": "value to be used by all configurations",
       "overrides": {
-        "scheme pattern 1": "a different string to be used by schemes matching 'scheme pattern 1'",
-        "scheme pattern 2": "a different string to be used by schemes matching 'scheme pattern 2'"   
+        "config pattern 1": "a different string to be used by configurations matching 'config pattern 1'",
+        "config pattern 2": "a different string to be used by configurations matching 'config pattern 2'"
       }
   }
 }
@@ -62,13 +62,13 @@ The "key" will be used as a static property name in a `class` so should have a f
 - `Reference`: See [Reference Properties](#reference-properties) below.
 - Enum types. Set the `type` to the name of the enum, set the value to be the case, preceded by a `.`, so `.thing`. If you need enums from a custom module, add a string array of imports to the template section.
 
-`overrides` contains values that are different to the provided `defaultValue`. The keys in this dictionary should be a regex pattern to match the scheme passed in. The values should be the same type as the `defaultValue` as specified by `type`. If two overridden values could match, the first suitable value found is used. `overrides` is optional, if not provided, all schemes will use the `defaultValue`.
+`overrides` contains values that are different to the provided `defaultValue`. The keys in this dictionary should be a regex pattern to match the configuration name passed in. The values should be the same type as the `defaultValue` as specified by `type`. If two overridden values could match, the first suitable value found is used. `overrides` is optional, if not provided, all configurations will use the `defaultValue`.
 
 Note properties can also be grouped together as per the second example. Any number of properties can be added to a named group, which will create a nested class within the parent config class with the properties attached.
 
 #### Associated Properties
 
-Sometimes you may want to map a property to the output of another property, rather than a passed in scheme. Take the example below:
+Sometimes you may want to map a property to the output of another property, rather than a passed in configuration name. Take the example below:
 
 ```
 {
@@ -92,7 +92,7 @@ Sometimes you may want to map a property to the output of another property, rath
 }
 ```
 
-The `logoName` property has an `associatedProperty`, which ties it's `overrides` to the value of `host` instead of the passed in scheme. This allows for more concise override lists, as in the example above both the "test" and "stage" scheme will produce a "logo-test.png" logoName.
+The `logoName` property has an `associatedProperty`, which ties it's `overrides` to the value of `host` instead of the passed in configuration. This allows for more concise override lists, as in the example above both the "test" and "stage" configuration will produce a "logo-test.png" logoName.
 
 Note that there are a couple of caveats when using `associatedProperty`:
 
@@ -101,7 +101,7 @@ Note that there are a couple of caveats when using `associatedProperty`:
 
 #### Reference Properties
 
-Sometimes you may want to make a property return the output of another property, depending on the passed in scheme. For example:
+Sometimes you may want to make a property return the output of another property, depending on the passed in configuration. For example:
 ```
 {
   "red": {
@@ -116,13 +116,13 @@ Sometimes you may want to make a property return the output of another property,
     "type": "Reference",
     "defaultValue": "red",
     "overrides": {
-      "greenScheme": "green"
+      "greenConfig": "green"
     }
   }
 }
 ```
 
-The `textColour` property will be `return red` for all schemes bar the `greenScheme` where it will be `return green`.
+The `textColour` property will be `return red` for all configurations bar the `greenConfig` where it will be `return green`.
 
 ### Enum
 This schema should be used for creating enums.
@@ -137,7 +137,7 @@ A sample of the schema is:
   "key": {
     "defaultValue": "",
     "overrides": {
-      "scheme pattern 1": "a dffierent string to be used by schemes matching 'scheme pattern 1'"
+      "config pattern 1": "a different string to be used by configurations matching 'config pattern 1'"
     }
   }
 }

--- a/Sources/Config/Arguments.swift
+++ b/Sources/Config/Arguments.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 struct Arguments {
-    let scheme: String
+    let name: String
     let configURL: URL
     let additionalExtension: String?
 }
@@ -17,16 +17,16 @@ struct Arguments {
 extension Arguments {
 
     enum Option: String {
-        case scheme = "--scheme"
+        case configName = "--name"
         case configPath = "--configPath"
         case additionalExtension = "--ext"
 
-        static let all: [Option] = [.scheme, .configPath, .additionalExtension]
+        static let all: [Option] = [.configName, .configPath, .additionalExtension]
 
         var usage: String {
             switch self {
-            case .scheme:
-                return "\(rawValue)\t\t(Required) The scheme to generate for"
+            case .configName:
+                return "\(rawValue)\t\t(Required) The configuration to generate for"
             case .configPath:
                 return "\(rawValue)\t\t(Required) The path to the configuration files"
             case .additionalExtension:
@@ -42,10 +42,10 @@ extension Arguments {
     init(argumentList: [String] = CommandLine.arguments) throws {
         let argumentPairs: [Arguments.Option: String] = argumentList.arguments()
 
-        guard let scheme = argumentPairs[.scheme],
+        guard let name = argumentPairs[.configName],
             let configPath = argumentPairs[.configPath] else {
             let missingArgs = [
-                argumentPairs.keys.contains(.scheme) ? nil : "scheme",
+                argumentPairs.keys.contains(.configName) ? nil : "name",
                 argumentPairs.keys.contains(.configPath) ? nil : "configPath"
             ].compactMap { $0 }
             let lines: [String] = [
@@ -57,7 +57,7 @@ extension Arguments {
             throw MissingArgumentError(missingArguments: missingArgs)
         }
 
-        self.scheme = scheme
+        self.name = name
         self.configURL = URL(fileURLWithPath: configPath)
         self.additionalExtension = argumentPairs[.additionalExtension]
     }

--- a/Sources/Config/ConfigGenerator.swift
+++ b/Sources/Config/ConfigGenerator.swift
@@ -27,7 +27,7 @@ public class ConfigGenerator {
                 throw ConfigError.badJSON
             }
             guard let template = templates.first(where: { $0.canHandle(config: config) == true }) else { throw ConfigError.noTemplate }
-            let configurationFile = try template.init(config: config, name: url.deletingPathExtension().lastPathComponent, scheme: arguments.scheme, source: url.deletingLastPathComponent())
+            let configurationFile = try template.init(config: config, name: url.deletingPathExtension().lastPathComponent, configName: arguments.name, source: url.deletingLastPathComponent())
             var swiftOutput: URL
             if let filename = configurationFile.filename {
                 swiftOutput = url.deletingLastPathComponent().appendingPathComponent(filename)

--- a/Sources/Config/ConfigurationProperty.swift
+++ b/Sources/Config/ConfigurationProperty.swift
@@ -80,20 +80,20 @@ struct ConfigurationProperty<T>: Property, AssociatedPropertyKeyProviding {
         return pattern.pattern
     }
 
-    func value(for scheme: String) -> T {
+    func value(for configName: String) -> T {
 
         if let override = overrides.first(where: { item in
             if associatedProperty != nil {
-                return item.key == scheme
+                return item.key == configName
             }
-            return scheme.range(of: pattern(for: item.key), options: .regularExpression) != nil
+            return configName.range(of: pattern(for: item.key), options: .regularExpression) != nil
         }) {
             return override.value
         }
         return defaultValue
     }
 
-    func propertyDeclaration(for scheme: String, iv: IV, encryptionKey: String?, requiresNonObjCDeclarations: Bool, isPublic: Bool, indentWidth: Int) -> String {
+    func propertyDeclaration(for configName: String, iv: IV, encryptionKey: String?, requiresNonObjCDeclarations: Bool, isPublic: Bool, indentWidth: Int) -> String {
         var template: String = ""
         if let description = description {
             template += "\(String.indent(for: indentWidth))/// \(description)\n"
@@ -107,7 +107,7 @@ struct ConfigurationProperty<T>: Property, AssociatedPropertyKeyProviding {
         } else {
             template += "\(String.indent(for: indentWidth))\(isPublic ? "public " : "")static let {key}: {typeName} = {value}"
         }
-        let propertyValue = value(for: scheme)
+        let propertyValue = value(for: configName)
         let outputValue: String
         if let type = type {
             outputValue = type.valueDeclaration(for: propertyValue, iv: iv, key: encryptionKey)
@@ -119,8 +119,8 @@ struct ConfigurationProperty<T>: Property, AssociatedPropertyKeyProviding {
             .replacingOccurrences(of: "{value}", with: outputValue)
     }
 
-    func keyValue(for scheme: String) -> String {
-        let overrideValue = overrides.first(where: { scheme.range(of: pattern(for: $0.key), options: .regularExpression) != nil })?.value ?? defaultValue
+    func keyValue(for configName: String) -> String {
+        let overrideValue = overrides.first(where: { configName.range(of: pattern(for: $0.key), options: .regularExpression) != nil })?.value ?? defaultValue
         guard let value = overrideValue as? String else {
             fatalError("Cannot retrieve keyValue for type \(T.self). Type must be String.")
         }

--- a/Sources/Config/CustomType.swift
+++ b/Sources/Config/CustomType.swift
@@ -55,21 +55,21 @@ struct CustomProperty: Property {
         return customType.typeName
     }
 
-    func propertyDeclaration(for scheme: String, iv: IV, encryptionKey: String?, requiresNonObjCDeclarations: Bool, isPublic: Bool, indentWidth: Int) -> String {
+    func propertyDeclaration(for configName: String, iv: IV, encryptionKey: String?, requiresNonObjCDeclarations: Bool, isPublic: Bool, indentWidth: Int) -> String {
         return template(for: description, isPublic: isPublic, indentWidth: indentWidth).replacingOccurrences(of: "{key}", with: key)
             .replacingOccurrences(of: "{typeName}", with: typeName)
-            .replacingOccurrences(of: "{value}", with: outputValue(for: scheme, type: customType))
+            .replacingOccurrences(of: "{value}", with: outputValue(for: configName, type: customType))
     }
 
-    private func outputValue(for scheme: String, type: CustomType) -> String {
+    private func outputValue(for configName: String, type: CustomType) -> String {
         let value: Any
-        if let override = overrides[scheme] {
+        if let override = overrides[configName] {
             value = override
         } else {
             value = defaultValue
         }
         let template = CustomPropertyValue(value: value)
-        return template.outputValue(for: scheme, type: type)
+        return template.outputValue(for: configName, type: type)
     }
 }
 
@@ -94,20 +94,20 @@ struct CustomPropertyArray: Property {
         return "[\(customType.typeName)]"
     }
 
-    func propertyDeclaration(for scheme: String, iv: IV, encryptionKey: String?, requiresNonObjCDeclarations: Bool, isPublic: Bool, indentWidth: Int) -> String {
+    func propertyDeclaration(for configName: String, iv: IV, encryptionKey: String?, requiresNonObjCDeclarations: Bool, isPublic: Bool, indentWidth: Int) -> String {
         return template(for: description, isPublic: isPublic, indentWidth: indentWidth).replacingOccurrences(of: "{key}", with: key)
             .replacingOccurrences(of: "{typeName}", with: typeName)
-            .replacingOccurrences(of: "{value}", with: outputValue(for: scheme, type: customType))
+            .replacingOccurrences(of: "{value}", with: outputValue(for: configName, type: customType))
     }
 
-    private func outputValue(for scheme: String, type: CustomType) -> String {
+    private func outputValue(for configName: String, type: CustomType) -> String {
         let value: [Any]
-        if let override = overrides.first(where: { scheme.range(of: $0.key, options: .regularExpression) != nil }) {
+        if let override = overrides.first(where: { configName.range(of: $0.key, options: .regularExpression) != nil }) {
             value = override.value
         } else {
             value = defaultValue
         }
-        return "[" + value.map { CustomPropertyValue(value: $0).outputValue(for: scheme, type: type) }
+        return "[" + value.map { CustomPropertyValue(value: $0).outputValue(for: configName, type: type) }
             .joined(separator: ", ") + "]"
     }
 }
@@ -143,7 +143,7 @@ private func template(for description: String?, isPublic: Bool, indentWidth: Int
 private struct CustomPropertyValue {
     let value: Any
 
-    func outputValue(for scheme: String, type: CustomType) -> String {
+    func outputValue(for configName: String, type: CustomType) -> String {
         switch type.placeholders.count {
         case 0:
             return type.initialiser

--- a/Sources/Config/EnumConfiguration.swift
+++ b/Sources/Config/EnumConfiguration.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 private let template = """
-/* {filename} auto-generated from {scheme} */
+/* {filename} auto-generated from {configName} */
 import Foundation
 
 public enum {filename}: {type} {
@@ -25,14 +25,14 @@ struct EnumConfiguration: Template {
     }
 
     let name: String
-    let scheme: String
+    let configName: String
     let type: String
 
     let properties: [String: Property]
 
-    init(config: [String: Any], name: String, scheme: String, source: URL) throws {
+    init(config: [String: Any], name: String, configName: String, source: URL) throws {
         self.name = name
-        self.scheme = scheme
+        self.configName = configName
         guard let template = config["template"] as? [String: String],
             let type = template["rawType"] else { throw EnumError.noType }
         self.type = type
@@ -59,13 +59,13 @@ struct EnumConfiguration: Template {
     var description: String {
         let propertyDeclarations = properties.compactMap { property -> String? in
             guard let configProperty = property.value as? ConfigurationProperty<String> else { return nil }
-            let value = configProperty.value(for: self.scheme)
+            let value = configProperty.value(for: self.configName)
             return "    case \(configProperty.key)" + (value.isEmpty ? "" : ##" = #"\##(value)"#"##)
         }
         .sorted()
         .joined(separator: "\n")
         return template.replacingOccurrences(of: "{filename}", with: name)
-            .replacingOccurrences(of: "{scheme}", with: scheme)
+            .replacingOccurrences(of: "{configName}", with: configName)
             .replacingOccurrences(of: "{type}", with: type)
             .replacingOccurrences(of: "{contents}", with: propertyDeclarations)
     }

--- a/Sources/Config/IV.swift
+++ b/Sources/Config/IV.swift
@@ -19,7 +19,7 @@ struct IV: Property {
         hash = try dict.hashRepresentation()
     }
 
-    func propertyDeclaration(for scheme: String, iv: IV, encryptionKey: String?, requiresNonObjCDeclarations: Bool, isPublic: Bool, indentWidth: Int) -> String {
+    func propertyDeclaration(for configName: String, iv: IV, encryptionKey: String?, requiresNonObjCDeclarations: Bool, isPublic: Bool, indentWidth: Int) -> String {
         return "\(String.indent(for: indentWidth))\(isPublic ? "public " : "")static let \(key): \(typeName) = \(byteArrayOutput(from: Array(hash.utf8)))"
     }
 }

--- a/Sources/Config/Property.swift
+++ b/Sources/Config/Property.swift
@@ -9,14 +9,14 @@
 import Foundation
 
 protocol AssociatedPropertyKeyProviding {
-    func keyValue(for scheme: String) -> String
+    func keyValue(for configName: String) -> String
 }
 
 protocol Property {
     var key: String { get }
     var typeName: String { get }
     var associatedProperty: String? { get }
-    func propertyDeclaration(for scheme: String, iv: IV, encryptionKey: String?, requiresNonObjCDeclarations: Bool, isPublic: Bool, indentWidth: Int) -> String
+    func propertyDeclaration(for configName: String, iv: IV, encryptionKey: String?, requiresNonObjCDeclarations: Bool, isPublic: Bool, indentWidth: Int) -> String
 }
 
 private func dictionaryValue(_ dict: [String: Any]) -> String {

--- a/Sources/Config/ReferenceProperty.swift
+++ b/Sources/Config/ReferenceProperty.swift
@@ -30,16 +30,16 @@ struct ReferenceProperty: Property {
         self.description = dict["description"] as? String
     }
 
-    func value(for scheme: String) -> String {
+    func value(for configName: String) -> String {
         if let override = overrides.first(where: { item in
-            return scheme.range(of: item.key, options: .regularExpression) != nil
+            return configName.range(of: item.key, options: .regularExpression) != nil
         }) {
             return override.value
         }
         return defaultValue
     }
 
-    func propertyDeclaration(for scheme: String, iv: IV, encryptionKey: String?, requiresNonObjCDeclarations: Bool, isPublic: Bool, indentWidth: Int) -> String {
+    func propertyDeclaration(for configName: String, iv: IV, encryptionKey: String?, requiresNonObjCDeclarations: Bool, isPublic: Bool, indentWidth: Int) -> String {
         var template: String = ""
         if let description = description {
             template += "\(String.indent(for: indentWidth))/// \(description)\n"
@@ -47,11 +47,11 @@ struct ReferenceProperty: Property {
         if requiresNonObjCDeclarations {
             template += """
             \(String.indent(for: indentWidth))@nonobjc\(isPublic ? " public" : "") static var \(key): \(typeName) {
-            \(String.indent(for: indentWidth + 1))return \(value(for: scheme))
+            \(String.indent(for: indentWidth + 1))return \(value(for: configName))
             \(String.indent(for: indentWidth))}
             """
         } else {
-            template += "\(String.indent(for: indentWidth))\(isPublic ? "public " : "")static let \(key): \(typeName) = \(value(for: scheme))"
+            template += "\(String.indent(for: indentWidth))\(isPublic ? "public " : "")static let \(key): \(typeName) = \(value(for: configName))"
         }
         return template
     }

--- a/Sources/Config/Template.swift
+++ b/Sources/Config/Template.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 protocol Template: CustomStringConvertible {
-    init(config: [String: Any], name: String, scheme: String, source: URL) throws
+    init(config: [String: Any], name: String, configName: String, source: URL) throws
 
     static func canHandle(config: [String: Any]) -> Bool
 

--- a/Tests/ConfigTests/ArgumentsTests.swift
+++ b/Tests/ConfigTests/ArgumentsTests.swift
@@ -14,11 +14,11 @@ class ArgumentsTests: XCTestCase {
     func testItParsesCorrectArguments() throws {
         let arguments = try Arguments(argumentList: [
             "binary",
-            "--scheme", "test-scheme",
+            "--name", "test-name",
             "--configPath", "/config/path",
             "--ext", "ext"
         ])
-        expect(arguments.scheme).to(equal("test-scheme"))
+        expect(arguments.name).to(equal("test-name"))
         expect(arguments.configURL.path).to(equal("/config/path"))
         expect(arguments.additionalExtension).to(equal("ext"))
     }
@@ -26,7 +26,7 @@ class ArgumentsTests: XCTestCase {
     func testTheExtensionIsOptional() throws {
         let arguments = try Arguments(argumentList: [
             "binary",
-            "--scheme", "test-scheme",
+            "--name", "test-name",
             "--configPath", "/config/path"
         ])
         expect(arguments.additionalExtension).to(beNil())
@@ -40,7 +40,7 @@ class ArgumentsTests: XCTestCase {
             ])
             fail("Error should have been thrown")
         } catch let error as Arguments.MissingArgumentError {
-            expect(error.missingArguments).to(equal(["scheme", "configPath"]))
+            expect(error.missingArguments).to(equal(["name", "configPath"]))
         } catch {
             fail("Wrong error thrown")
         }
@@ -50,7 +50,7 @@ class ArgumentsTests: XCTestCase {
         do {
             _ = try Arguments(argumentList: [
                 "binary",
-                "--scheme", "test-scheme",
+                "--name", "test-name",
             ])
             fail("Error should have been thrown")
         } catch let error as Arguments.MissingArgumentError {
@@ -60,7 +60,7 @@ class ArgumentsTests: XCTestCase {
         }
     }
 
-    func testItThrowsAnExceptionWhenSchemeIsNotPassed() {
+    func testItThrowsAnExceptionWhenConfigNameIsNotPassed() {
         do {
             _ = try Arguments(argumentList: [
                 "binary",
@@ -68,7 +68,7 @@ class ArgumentsTests: XCTestCase {
             ])
             fail("Error should have been thrown")
         } catch let error as Arguments.MissingArgumentError {
-            expect(error.missingArguments).to(equal(["scheme"]))
+            expect(error.missingArguments).to(equal(["name"]))
         } catch {
             fail("Wrong error thrown")
         }

--- a/Tests/ConfigTests/ConfigGeneratorTests.swift
+++ b/Tests/ConfigTests/ConfigGeneratorTests.swift
@@ -65,7 +65,7 @@ class ConfigGeneratorTests: XCTestCase {
         return [
             "",
             "--configPath", tempURL.path,
-            "--scheme", "any",
+            "--name", "any",
             "--ext", "ext"
         ]
     }
@@ -111,9 +111,9 @@ private let expectedStrings = [
 
     // swiftlint:disable force_unwrapping type_body_length file_length superfluous_disable_command
     public enum standard {
-        public static let float: Float = 0.0
+        public static let configName: String = #"any"#
 
-        public static let schemeName: String = #"any"#
+        public static let float: Float = 0.0
     }
 
     // swiftlint:enable force_unwrapping type_body_length file_length superfluous_disable_command

--- a/Tests/ConfigTests/ConfigurationFileReferenceSourceTests.swift
+++ b/Tests/ConfigTests/ConfigurationFileReferenceSourceTests.swift
@@ -30,7 +30,7 @@ class ConfigurationFileReferenceSourceTests: XCTestCase {
     }
 
     func testItOutputsAConfigurationWithAReferenceSource() throws {
-        let config = try ConfigurationFile(config: configurationWithReferenceInSource, name: "Test", scheme: "any", source: tempURL)
+        let config = try ConfigurationFile(config: configurationWithReferenceInSource, name: "Test", configName: "any", source: tempURL)
         let expectedOutput = """
         /* Test+ReferenceTest.swift auto-generated from any */
 
@@ -48,7 +48,7 @@ class ConfigurationFileReferenceSourceTests: XCTestCase {
     }
 
     func testItOutputsAConfigurationWithAReferenceSourceUsingOverrides() throws {
-        let config = try ConfigurationFile(config: configurationWithReferenceInSource, name: "Test", scheme: "override", source: tempURL)
+        let config = try ConfigurationFile(config: configurationWithReferenceInSource, name: "Test", configName: "override", source: tempURL)
         let expectedOutput = """
         /* Test+ReferenceTest.swift auto-generated from override */
 

--- a/Tests/ConfigTests/ConfigurationFileTests.swift
+++ b/Tests/ConfigTests/ConfigurationFileTests.swift
@@ -16,9 +16,9 @@ class ConfigurationFileTests: XCTestCase {
     }
 
     func testItCanBeInitialisedFromAnEmptyConfiguration() throws {
-        let config = try ConfigurationFile(config: givenAConfigDictionary(), name: "Test", scheme: "any", source: URL(fileURLWithPath: "/"))
+        let config = try ConfigurationFile(config: givenAConfigDictionary(), name: "Test", configName: "any", source: URL(fileURLWithPath: "/"))
         expect(config.name).to(equal("Test"))
-        expect(config.scheme).to(equal("any"))
+        expect(config.configName).to(equal("any"))
         let testIV = try IV(dict: [:])
         expect(config.iv.hash).to(equal(testIV.hash))
         expect(config.filename).to(beNil())
@@ -29,7 +29,7 @@ class ConfigurationFileTests: XCTestCase {
 
         // swiftlint:disable force_unwrapping type_body_length file_length superfluous_disable_command
         public enum Test {
-            public static let schemeName: String = #"any"#
+            public static let configName: String = #"any"#
         }
 
         // swiftlint:enable force_unwrapping type_body_length file_length superfluous_disable_command
@@ -40,7 +40,7 @@ class ConfigurationFileTests: XCTestCase {
 
     func testItCanOutputAnExtension() throws {
         let dict = givenAConfigDictionary(withTemplate: extensionTemplate)
-        let config = try ConfigurationFile(config: dict, name: "Test", scheme: "any", source: URL(fileURLWithPath: "/"))
+        let config = try ConfigurationFile(config: dict, name: "Test", configName: "any", source: URL(fileURLWithPath: "/"))
         let testIV = try IV(dict: dict)
         expect(config.iv.hash).to(equal(testIV.hash))
         expect(config.filename).to(equal("UIColor+Test"))
@@ -62,7 +62,7 @@ class ConfigurationFileTests: XCTestCase {
 
     func testItCanOutputAdditionalImports() throws {
         let dict = givenAConfigDictionary(withTemplate: importsTemplate)
-        let config = try ConfigurationFile(config: dict, name: "Test", scheme: "any", source: URL(fileURLWithPath: "/"))
+        let config = try ConfigurationFile(config: dict, name: "Test", configName: "any", source: URL(fileURLWithPath: "/"))
         let expectedOutput = """
         /* Test.swift auto-generated from any */
 
@@ -72,7 +72,7 @@ class ConfigurationFileTests: XCTestCase {
 
         // swiftlint:disable force_unwrapping type_body_length file_length superfluous_disable_command
         public enum Test {
-            public static let schemeName: String = #"any"#
+            public static let configName: String = #"any"#
         }
 
         // swiftlint:enable force_unwrapping type_body_length file_length superfluous_disable_command
@@ -82,7 +82,7 @@ class ConfigurationFileTests: XCTestCase {
     }
 
     func testItCanOutputEncryptedValues() throws {
-        let config = try ConfigurationFile(config: configWithEncryption, name: "Test", scheme: "any", source: URL(fileURLWithPath: "/"))
+        let config = try ConfigurationFile(config: configWithEncryption, name: "Test", configName: "any", source: URL(fileURLWithPath: "/"))
         let expectedOutput = """
         /* Test.swift auto-generated from any */
 
@@ -90,11 +90,11 @@ class ConfigurationFileTests: XCTestCase {
 
         // swiftlint:disable force_unwrapping type_body_length file_length superfluous_disable_command
         public enum Test {
+            public static let configName: String = #"any"#
+
             public static let encryptionKey: [UInt8] = [UInt8(116), UInt8(104), UInt8(101), UInt8(45), UInt8(107), UInt8(101), UInt8(121), UInt8(45), UInt8(116), UInt8(111), UInt8(45), UInt8(116), UInt8(104), UInt8(101), UInt8(45), UInt8(115), UInt8(101), UInt8(99), UInt8(114), UInt8(101), UInt8(116)]
 
             public static let encryptionKeyIV: [UInt8] = [UInt8(97), UInt8(53), UInt8(101), UInt8(49), UInt8(49), UInt8(97), UInt8(100), UInt8(57), UInt8(98), UInt8(53), UInt8(56), UInt8(55), UInt8(52), UInt8(56), UInt8(101), UInt8(48), UInt8(52), UInt8(56), UInt8(57), UInt8(57), UInt8(56), UInt8(97), UInt8(102), UInt8(53), UInt8(55), UInt8(55), UInt8(97), UInt8(55), UInt8(98), UInt8(97), UInt8(48), UInt8(102)]
-
-            public static let schemeName: String = #"any"#
 
             public static let somethingSecret: [UInt8] = [UInt8(72), UInt8(248), UInt8(24), UInt8(73), UInt8(30), UInt8(207), UInt8(159), UInt8(0), UInt8(65), UInt8(147), UInt8(20), UInt8(183), UInt8(214), UInt8(231), UInt8(169), UInt8(3)]
         }
@@ -106,9 +106,9 @@ class ConfigurationFileTests: XCTestCase {
     }
 
     func testItUsesOverridesAndOrdersProperties() throws {
-        let config = try ConfigurationFile(config: configWithOverride, name: "Test", scheme: "scheme", source: URL(fileURLWithPath: "/"))
+        let config = try ConfigurationFile(config: configWithOverride, name: "Test", configName: "name", source: URL(fileURLWithPath: "/"))
         let expectedOutput = """
-        /* Test.swift auto-generated from scheme */
+        /* Test.swift auto-generated from name */
 
         import Foundation
 
@@ -116,7 +116,7 @@ class ConfigurationFileTests: XCTestCase {
         public enum Test {
             public static let anotherProperty: Int = 1
 
-            public static let schemeName: String = #"scheme"#
+            public static let configName: String = #"name"#
 
             public static let testProperty: String = #"A test"#
         }
@@ -128,19 +128,19 @@ class ConfigurationFileTests: XCTestCase {
     }
 
     func testItItCanWriteReferenceProperties() throws {
-        let config = try ConfigurationFile(config: configWithReferenceProperty, name: "Test", scheme: "scheme", source: URL(fileURLWithPath: "/"))
+        let config = try ConfigurationFile(config: configWithReferenceProperty, name: "Test", configName: "name", source: URL(fileURLWithPath: "/"))
         let expectedOutput = """
-        /* Test.swift auto-generated from scheme */
+        /* Test.swift auto-generated from name */
 
         import Foundation
 
         // swiftlint:disable force_unwrapping type_body_length file_length superfluous_disable_command
         public enum Test {
+            public static let configName: String = #"name"#
+
             public static let property: String = #"A test"#
 
             public static let referenceProperty: String = property
-
-            public static let schemeName: String = #"scheme"#
         }
 
         // swiftlint:enable force_unwrapping type_body_length file_length superfluous_disable_command
@@ -150,7 +150,7 @@ class ConfigurationFileTests: XCTestCase {
     }
 
     func testItCanWriteNonObjcProperties() throws {
-        let config = try ConfigurationFile(config: givenAConfigDictionary(withTemplate: nonObjCTemplate), name: "Test", scheme: "any", source: URL(fileURLWithPath: "/"))
+        let config = try ConfigurationFile(config: givenAConfigDictionary(withTemplate: nonObjCTemplate), name: "Test", configName: "any", source: URL(fileURLWithPath: "/"))
         let expectedOutput = """
         /* Test.swift auto-generated from any */
 
@@ -158,7 +158,7 @@ class ConfigurationFileTests: XCTestCase {
 
         // swiftlint:disable force_unwrapping type_body_length file_length superfluous_disable_command
         public enum Test {
-            @nonobjc public static var schemeName: String {
+            @nonobjc public static var configName: String {
                 return #"any"#
             }
         }
@@ -170,15 +170,15 @@ class ConfigurationFileTests: XCTestCase {
     }
 
     func testItOutputsGroups() throws {
-        let config = try ConfigurationFile(config: groupedConfig, name: "Test", scheme: "scheme", source: URL(fileURLWithPath: "/"))
+        let config = try ConfigurationFile(config: groupedConfig, name: "Test", configName: "name", source: URL(fileURLWithPath: "/"))
         let expectedOutput = """
-        /* Test.swift auto-generated from scheme */
+        /* Test.swift auto-generated from name */
 
         import Foundation
 
         // swiftlint:disable force_unwrapping type_body_length file_length superfluous_disable_command
         public enum Test {
-            public static let schemeName: String = #"scheme"#
+            public static let configName: String = #"name"#
 
             public enum FirstGroup {
                 public static let testProperty: String = #"A test"#
@@ -196,9 +196,9 @@ class ConfigurationFileTests: XCTestCase {
     }
 
     func testAssociatedPropertiesAreOutputForDefaults() throws {
-        let config = try ConfigurationFile(config: configWithAssociatedProperties, name: "Test", scheme: "scheme", source: URL(fileURLWithPath: "/"))
+        let config = try ConfigurationFile(config: configWithAssociatedProperties, name: "Test", configName: "name", source: URL(fileURLWithPath: "/"))
         let expectedOutput = """
-        /* Test.swift auto-generated from scheme */
+        /* Test.swift auto-generated from name */
 
         import Foundation
 
@@ -207,9 +207,9 @@ class ConfigurationFileTests: XCTestCase {
             /// API Host
             public static let host: String = #"dev.dave.com"#
 
-            public static let hostKey: String = #"a-secret-key"#
+            public static let configName: String = #"name"#
 
-            public static let schemeName: String = #"scheme"#
+            public static let hostKey: String = #"a-secret-key"#
         }
 
         // swiftlint:enable force_unwrapping type_body_length file_length superfluous_disable_command
@@ -218,8 +218,8 @@ class ConfigurationFileTests: XCTestCase {
         expect(config.description).to(equal(expectedOutput))
     }
 
-    func testAssociatedPropertiesAreOutputForScheme() throws {
-        let config = try ConfigurationFile(config: configWithAssociatedProperties, name: "Test", scheme: "prod", source: URL(fileURLWithPath: "/"))
+    func testAssociatedPropertiesAreOutputForConfiguration() throws {
+        let config = try ConfigurationFile(config: configWithAssociatedProperties, name: "Test", configName: "prod", source: URL(fileURLWithPath: "/"))
         let expectedOutput = """
         /* Test.swift auto-generated from prod */
 
@@ -230,9 +230,9 @@ class ConfigurationFileTests: XCTestCase {
             /// API Host
             public static let host: String = #"dave.com"#
 
-            public static let hostKey: String = #"the-prod-key"#
+            public static let configName: String = #"prod"#
 
-            public static let schemeName: String = #"prod"#
+            public static let hostKey: String = #"the-prod-key"#
         }
 
         // swiftlint:enable force_unwrapping type_body_length file_length superfluous_disable_command
@@ -242,7 +242,7 @@ class ConfigurationFileTests: XCTestCase {
     }
 
     func testPropertiesAreOutputForVariousTypes() throws {
-        let config = try ConfigurationFile(config: configurationWithDifferentTypes, name: "Test", scheme: "any", source: URL(fileURLWithPath: "/"))
+        let config = try ConfigurationFile(config: configurationWithDifferentTypes, name: "Test", configName: "any", source: URL(fileURLWithPath: "/"))
         let expectedOutput = """
         /* Test.swift auto-generated from any */
 
@@ -252,6 +252,8 @@ class ConfigurationFileTests: XCTestCase {
         public enum Test {
             public static let bool: Bool = true
 
+            public static let configName: String = #"any"#
+
             public static let dictionary: [String: Any] = ["bool": true, "dict": [:], "key": 12]
 
             public static let float: Float = 0.0
@@ -259,8 +261,6 @@ class ConfigurationFileTests: XCTestCase {
             public static let optionalInt: Int? = nil
 
             public static let optionalString: String? = nil
-
-            public static let schemeName: String = #"any"#
 
             public static let stringArray: [String] = []
         }
@@ -272,7 +272,7 @@ class ConfigurationFileTests: XCTestCase {
     }
 
     func testPropertiesAreOutputForCustomTypes() throws {
-        let config = try ConfigurationFile(config: configurationWithCustomType, name: "Test", scheme: "any", source: URL(fileURLWithPath: "/"))
+        let config = try ConfigurationFile(config: configurationWithCustomType, name: "Test", configName: "any", source: URL(fileURLWithPath: "/"))
         let expectedOutput = """
         /* Test.swift auto-generated from any */
 
@@ -282,9 +282,9 @@ class ConfigurationFileTests: XCTestCase {
         public enum Test {
             public static let arrayProperty: [CustomType] = [CustomType(param: #"Value"#)]
 
-            public static let property: CustomType = CustomType(param: #"Value"#)
+            public static let configName: String = #"any"#
 
-            public static let schemeName: String = #"any"#
+            public static let property: CustomType = CustomType(param: #"Value"#)
         }
 
         // swiftlint:enable force_unwrapping type_body_length file_length superfluous_disable_command
@@ -294,7 +294,7 @@ class ConfigurationFileTests: XCTestCase {
     }
 
     func testItUsesADefaultTypeIfOneIsNotSpecified() throws {
-        let config = try ConfigurationFile(config: configurationWithDefaultType, name: "Test", scheme: "any", source: URL(fileURLWithPath: "/"))
+        let config = try ConfigurationFile(config: configurationWithDefaultType, name: "Test", configName: "any", source: URL(fileURLWithPath: "/"))
         let expectedOutput = """
         /* Test.swift auto-generated from any */
 
@@ -302,9 +302,9 @@ class ConfigurationFileTests: XCTestCase {
 
         // swiftlint:disable force_unwrapping type_body_length file_length superfluous_disable_command
         public enum Test {
-            public static let property: String = #"test value"#
+            public static let configName: String = #"any"#
 
-            public static let schemeName: String = #"any"#
+            public static let property: String = #"test value"#
         }
 
         // swiftlint:enable force_unwrapping type_body_length file_length superfluous_disable_command
@@ -314,7 +314,7 @@ class ConfigurationFileTests: XCTestCase {
     }
 
     func testItCanUsePatternsForMatchingOverrides() throws {
-        let config = try ConfigurationFile(config: configurationWithCommonPatterns, name: "Test", scheme: "PROD", source: URL(fileURLWithPath: "/"))
+        let config = try ConfigurationFile(config: configurationWithCommonPatterns, name: "Test", configName: "PROD", source: URL(fileURLWithPath: "/"))
         let expectedOutput = """
         /* Test.swift auto-generated from PROD */
 
@@ -324,11 +324,11 @@ class ConfigurationFileTests: XCTestCase {
         public enum Test {
             public static let associatedProperty: String = #"correct"#
 
+            public static let configName: String = #"PROD"#
+
             public static let propertyNotUsingPattern: String = #"test value"#
 
             public static let propertyUsingPattern: String = #"test value"#
-
-            public static let schemeName: String = #"PROD"#
         }
 
         // swiftlint:enable force_unwrapping type_body_length file_length superfluous_disable_command
@@ -376,7 +376,7 @@ private let configWithOverride: [String: Any] = [
         "type": "Int",
         "defaultValue": 0,
         "overrides": [
-            "scheme": 1
+            "name": 1
         ]
     ]
 ]

--- a/Tests/ConfigTests/ConfigurationPropertyTests.swift
+++ b/Tests/ConfigTests/ConfigurationPropertyTests.swift
@@ -22,10 +22,10 @@ class ConfigurationPropertyTests: XCTestCase {
         ])
     }
 
-    func whenTheDeclarationIsWritten<T>(for configurationProperty: ConfigurationProperty<T>?, scheme: String = "any", encryptionKey: String? = nil, isPublic: Bool = false, requiresNonObjC: Bool = false, indentWidth: Int = 0) throws -> String? {
+    func whenTheDeclarationIsWritten<T>(for configurationProperty: ConfigurationProperty<T>?, configName: String = "any", encryptionKey: String? = nil, isPublic: Bool = false, requiresNonObjC: Bool = false, indentWidth: Int = 0) throws -> String? {
         let iv = try IV(dict: ["initialise": "me"])
         print("\(iv.hash)")
-        return configurationProperty?.propertyDeclaration(for: scheme, iv: iv, encryptionKey: encryptionKey, requiresNonObjCDeclarations: requiresNonObjC, isPublic: isPublic, indentWidth: indentWidth)
+        return configurationProperty?.propertyDeclaration(for: configName, iv: iv, encryptionKey: encryptionKey, requiresNonObjCDeclarations: requiresNonObjC, isPublic: isPublic, indentWidth: indentWidth)
     }
 
     func testItCanWriteADeclarationForAStringPropertyUsingTheDefaultValue() throws {
@@ -38,7 +38,7 @@ class ConfigurationPropertyTests: XCTestCase {
     func testItCanWriteADeclarationForAnEmptyStringProperty() throws {
         let stringProperty = givenAStringProperty()
         let expectedValue = ##"    static let test: String = """##
-        let actualValue = try whenTheDeclarationIsWritten(for: stringProperty, scheme: "empty")
+        let actualValue = try whenTheDeclarationIsWritten(for: stringProperty, configName: "empty")
         expect(actualValue).to(equal(expectedValue))
     }
 
@@ -70,14 +70,14 @@ class ConfigurationPropertyTests: XCTestCase {
     func testItCanGetAnOverrideForAnExactMatch() throws {
         let stringProperty = givenAStringProperty()
         let expectedValue = ##"    static let test: String = #"hello value"#"##
-        let actualValue = try whenTheDeclarationIsWritten(for: stringProperty, scheme: "hello")
+        let actualValue = try whenTheDeclarationIsWritten(for: stringProperty, configName: "hello")
         expect(actualValue).to(equal(expectedValue))
     }
 
     func testItCanGetAnOverrideForAPatternMatch() throws {
         let stringProperty = givenAStringProperty()
         let expectedValue = ##"    static let test: String = #"pattern value"#"##
-        let actualValue = try whenTheDeclarationIsWritten(for: stringProperty, scheme: "match-a-pattern")
+        let actualValue = try whenTheDeclarationIsWritten(for: stringProperty, configName: "match-a-pattern")
         expect(actualValue).to(equal(expectedValue))
     }
 
@@ -252,7 +252,7 @@ class ConfigurationPropertyTests: XCTestCase {
             ]
         ])
         let expectedValue = "    static let test: String? = nil"
-        let actualValue = try whenTheDeclarationIsWritten(for: property, scheme: "bla")
+        let actualValue = try whenTheDeclarationIsWritten(for: property, configName: "bla")
         expect(actualValue).to(equal(expectedValue))
     }
 
@@ -282,7 +282,7 @@ class ConfigurationPropertyTests: XCTestCase {
             ]
         ])
         let expectedValue = "    static let test: Int? = nil"
-        let actualValue = try whenTheDeclarationIsWritten(for: property, scheme: "bla")
+        let actualValue = try whenTheDeclarationIsWritten(for: property, configName: "bla")
         expect(actualValue).to(equal(expectedValue))
     }
 
@@ -304,7 +304,7 @@ class ConfigurationPropertyTests: XCTestCase {
         ]
         let property = ConfigurationProperty<String>(key: "test", typeHint: "String", dict: dict, patterns: [OverridePattern(source: ["alias": "barry", "pattern": "gary"])!])
         let expectedValue = ##"    static let test: String = #"pattern value"#"##
-        let actualValue = try whenTheDeclarationIsWritten(for: property, scheme: "gary")
+        let actualValue = try whenTheDeclarationIsWritten(for: property, configName: "gary")
         expect(actualValue).to(equal(expectedValue))
     }
 }

--- a/Tests/ConfigTests/CustomPropertyTests.swift
+++ b/Tests/ConfigTests/CustomPropertyTests.swift
@@ -45,7 +45,7 @@ class CustomPropertyTests: XCTestCase {
         expect(property.propertyDeclaration(for: "any", iv: try IV(dict: [:]), encryptionKey: nil, requiresNonObjCDeclarations: false, isPublic: true, indentWidth: 0)).to(equal(expectedValue))
     }
 
-    func testItOutputAPropertyDeclarationCorrectlyForAnOverriddenScheme() throws {
+    func testItOutputAPropertyDeclarationCorrectlyForAnOverriddenConfiguration() throws {
         let property = CustomProperty(key: "test", customType: givenACustomType(), dict: givenADictionaryWithValues())
         let expectedValue = """
             /// A description
@@ -142,7 +142,7 @@ class CustomPropertyArrayTests: XCTestCase {
         expect(property.propertyDeclaration(for: "any", iv: try IV(dict: [:]), encryptionKey: nil, requiresNonObjCDeclarations: false, isPublic: true, indentWidth: 0)).to(equal(expectedValue))
     }
 
-    func testItOutputsAPropertyForAnOverriddenScheme() {
+    func testItOutputsAPropertyForAnOverriddenConfiguration() {
         let property = CustomPropertyArray(key: "test", customType: givenACustomType(for: givenATypeDictionaryWithTypeAnnotations()), dict: givenADictionaryWithArrayValues())
         let expectedValue = """
             /// A description

--- a/Tests/ConfigTests/EnumConfigurationTests.swift
+++ b/Tests/ConfigTests/EnumConfigurationTests.swift
@@ -29,16 +29,16 @@ class EnumConfigurationTests: XCTestCase {
     }
 
     func testItInitialisesFromAValidDictionary() throws {
-        let config = try EnumConfiguration(config: enumConfiguration, name: "Test", scheme: "Any", source: URL(fileURLWithPath: "/"))
+        let config = try EnumConfiguration(config: enumConfiguration, name: "Test", configName: "Any", source: URL(fileURLWithPath: "/"))
         expect(config.name).to(equal("Test"))
-        expect(config.scheme).to(equal("Any"))
+        expect(config.configName).to(equal("Any"))
         expect(config.type).to(equal("String"))
         expect(config.properties).to(haveCount(3))
     }
 
     func testItThrowsANoTypeErrorForAnInvalidConfig() {
         do {
-            _ = try EnumConfiguration(config: invalidEnumConfiguration, name: "Test", scheme: "Any", source: URL(fileURLWithPath: "/"))
+            _ = try EnumConfiguration(config: invalidEnumConfiguration, name: "Test", configName: "Any", source: URL(fileURLWithPath: "/"))
             fail("Expected an error to be thrown")
         } catch let error as EnumConfiguration.EnumError {
             if error != .noType {
@@ -51,7 +51,7 @@ class EnumConfigurationTests: XCTestCase {
 
     func testItThrowsAnUnknownTypeErrorForAnUnsupportedRawType() {
         do {
-            _ = try EnumConfiguration(config: intEnumConfiguration, name: "Test", scheme: "Any", source: URL(fileURLWithPath: "/"))
+            _ = try EnumConfiguration(config: intEnumConfiguration, name: "Test", configName: "Any", source: URL(fileURLWithPath: "/"))
             fail("Expected an error to be thrown")
         } catch let error as EnumConfiguration.EnumError {
             if error != .unknownType {
@@ -63,9 +63,9 @@ class EnumConfigurationTests: XCTestCase {
     }
 
     func testItCanOutputAConfigFile() throws {
-        let config = try EnumConfiguration(config: enumConfiguration, name: "Test", scheme: "scheme", source: URL(fileURLWithPath: "/"))
+        let config = try EnumConfiguration(config: enumConfiguration, name: "Test", configName: "name", source: URL(fileURLWithPath: "/"))
         let expectedOutput = """
-        /* Test auto-generated from scheme */
+        /* Test auto-generated from name */
         import Foundation
 
         public enum Test: String {
@@ -91,7 +91,7 @@ let enumConfiguration: [String: Any] = [
     "secondCase": [
         "defaultValue": "Another Value",
         "overrides": [
-            "scheme": "Overridden Value"
+            "name": "Overridden Value"
         ]
     ],
     "emptyCase": [
@@ -110,7 +110,7 @@ let intEnumConfiguration: [String: Any] = [
     "secondCase": [
         "defaultValue": 1,
         "overrides": [
-            "scheme": 1
+            "name": 1
         ]
     ]
 ]

--- a/Tests/ConfigTests/ReferencePropertyTests.swift
+++ b/Tests/ConfigTests/ReferencePropertyTests.swift
@@ -21,10 +21,10 @@ class ReferencePropertyTests: XCTestCase {
         ], typeName: "String")
     }
 
-    func whenTheDeclarationIsWritten(for property: ReferenceProperty?, scheme: String = "any", encryptionKey: String? = nil, isPublic: Bool = false, requiresNonObjC: Bool = false, indentWidth: Int = 0) throws -> String? {
+    func whenTheDeclarationIsWritten(for property: ReferenceProperty?, configName: String = "any", encryptionKey: String? = nil, isPublic: Bool = false, requiresNonObjC: Bool = false, indentWidth: Int = 0) throws -> String? {
         let iv = try IV(dict: ["initialise": "me"])
         print("\(iv.hash)")
-        return property?.propertyDeclaration(for: scheme, iv: iv, encryptionKey: encryptionKey, requiresNonObjCDeclarations: requiresNonObjC, isPublic: isPublic, indentWidth: indentWidth)
+        return property?.propertyDeclaration(for: configName, iv: iv, encryptionKey: encryptionKey, requiresNonObjCDeclarations: requiresNonObjC, isPublic: isPublic, indentWidth: indentWidth)
     }
 
     func testItCanWriteADeclarationForAStringPropertyUsingTheDefaultValue() throws {
@@ -62,14 +62,14 @@ class ReferencePropertyTests: XCTestCase {
     func testItCanGetAnOverrideForAnExactMatch() throws {
         let property = givenAReferenceProperty()
         let expectedValue = "    static let test: String = helloValue"
-        let actualValue = try whenTheDeclarationIsWritten(for: property, scheme: "hello")
+        let actualValue = try whenTheDeclarationIsWritten(for: property, configName: "hello")
         expect(actualValue).to(equal(expectedValue))
     }
 
     func testItCanGetAnOverrideForAPatternMatch() throws {
         let property = givenAReferenceProperty()
         let expectedValue = "    static let test: String = patternValue"
-        let actualValue = try whenTheDeclarationIsWritten(for: property, scheme: "match-a-pattern")
+        let actualValue = try whenTheDeclarationIsWritten(for: property, configName: "match-a-pattern")
         expect(actualValue).to(equal(expectedValue))
     }
 

--- a/Tests/ConfigTests/TemplateTests.swift
+++ b/Tests/ConfigTests/TemplateTests.swift
@@ -12,13 +12,13 @@ import XCTest
 
 class TemplateTests: XCTestCase {
     func testThereIsADefaultFilename() throws {
-        let template = try TestTemplate(config: [:], name: "", scheme: "", source: URL(fileURLWithPath: "/"))
+        let template = try TestTemplate(config: [:], name: "", configName: "", source: URL(fileURLWithPath: "/"))
         expect(template.filename).to(beNil())
     }
 }
 
 struct TestTemplate: Template {
-    init(config: [String : Any], name: String, scheme: String, source: URL) throws {
+    init(config: [String : Any], name: String, configName: String, source: URL) throws {
     }
 
     static func canHandle(config: [String : Any]) -> Bool {


### PR DESCRIPTION
Replaces references to `scheme` throughout the codebase with the more generic `configName`, as this represents essentially just an identifier rather than a scheme.

Generated configuration seems to be in alphabetical order, hence the reordering of test values in some places.

Not 100% sure I'm happy with `configName` primarily because it results in the signature for the `ConfigurationFile` constructor looking like:

 `init(config: [String: Any], name: String, configName: String, source: URL)`

Other considerations were `environment` and `identifier`. Welcome any input on what might be best.