### PR TITLE
Add EnvironmentVariable property type

### DIFF
--- a/Sources/Config/ConfigurationFile.swift
+++ b/Sources/Config/ConfigurationFile.swift
@@ -100,7 +100,7 @@ func parseNextProperty(properties: [String: Property], pair: (key: String, value
     var copy = properties
     if let typeHint = PropertyType(rawValue: typeHintValue) {
         switch typeHint {
-        case .string, .url, .encrypted, .encryptionKey, .colour, .image, .regex, .environmentVariable:
+        case .string, .url, .encrypted, .encryptionKey, .colour, .image, .regex, .environmentVariable, .encryptedEnvironmentVariable:
             copy[pair.key] = ConfigurationProperty<String>(key: pair.key, typeHint: typeHintValue, dict: dict, patterns: patterns)
         case .optionalString:
             copy[pair.key] = ConfigurationProperty<String?>(key: pair.key, typeHint: typeHintValue, dict: dict, patterns: patterns)

--- a/Sources/Config/ConfigurationFile.swift
+++ b/Sources/Config/ConfigurationFile.swift
@@ -100,7 +100,7 @@ func parseNextProperty(properties: [String: Property], pair: (key: String, value
     var copy = properties
     if let typeHint = PropertyType(rawValue: typeHintValue) {
         switch typeHint {
-        case .string, .url, .encrypted, .encryptionKey, .colour, .image, .regex:
+        case .string, .url, .encrypted, .encryptionKey, .colour, .image, .regex, .environmentVariable:
             copy[pair.key] = ConfigurationProperty<String>(key: pair.key, typeHint: typeHintValue, dict: dict, patterns: patterns)
         case .optionalString:
             copy[pair.key] = ConfigurationProperty<String?>(key: pair.key, typeHint: typeHintValue, dict: dict, patterns: patterns)

--- a/Sources/Config/Property.swift
+++ b/Sources/Config/Property.swift
@@ -70,6 +70,7 @@ enum PropertyType: String {
     case regex = "Regex"
     case dynamicColour = "DynamicColour"
     case dynamicColourReference = "DynamicColourReference"
+    case environmentVariable = "EnvironmentVariable"
 
     var typeName: String {
         switch self {
@@ -83,6 +84,8 @@ enum PropertyType: String {
             return "UIImage"
         case .regex:
             return "NSRegularExpression"
+        case .environmentVariable:
+            return "String"
         default:
             return rawValue
         }
@@ -150,6 +153,13 @@ enum PropertyType: String {
             return dynamicColourValue(for: value as? [String: String])
         case .dynamicColourReference:
             return dynamicColourReferenceValue(for: value as? [String: String])
+        case .environmentVariable:
+            guard let environmentVariable = value as? String,
+                  let rawValue = getenv(environmentVariable),
+                  let stringValue = String(utf8String: rawValue) else {
+                return "\"\""
+            }
+            return "#\"\(stringValue)\"#"
         default:
             return "\(value)"
         }

--- a/Sources/Config/Property.swift
+++ b/Sources/Config/Property.swift
@@ -157,7 +157,7 @@ enum PropertyType: String {
             guard let environmentVariable = value as? String,
                   let rawValue = getenv(environmentVariable),
                   let stringValue = String(utf8String: rawValue) else {
-                return "\"\""
+                fatalError("Missing environment variable \(value)")
             }
             return "#\"\(stringValue)\"#"
         default:

--- a/Tests/ConfigTests/ConfigurationPropertyTests.swift
+++ b/Tests/ConfigTests/ConfigurationPropertyTests.swift
@@ -347,6 +347,22 @@ class ConfigurationPropertyTests: XCTestCase {
         expect(actualValue).to(equal(expectedValue))
     }
 
+    func testItCanWriteAnEnvironmentVariableProperty() throws {
+        // Set an environment variable using the libc API
+        setenv("SOMETHING", "testValue", 1)
+        let property = ConfigurationProperty<String>(key: "test", typeHint: "EnvironmentVariable", dict: ["defaultValue": "SOMETHING"])
+        let expectedValue = ##"    static let test: String = #"testValue"#"##
+        let actualValue = try whenTheDeclarationIsWritten(for: property)
+        expect(actualValue).to(equal(expectedValue))
+    }
+
+    func testItWritesAnEmptyStringForAnEnvironmentVariableThatIsNotSet() throws {
+        let property = ConfigurationProperty<String>(key: "test", typeHint: "EnvironmentVariable", dict: ["defaultValue": "DOESNT_EXIST"])
+        let expectedValue = ##"    static let test: String = """##
+        let actualValue = try whenTheDeclarationIsWritten(for: property)
+        expect(actualValue).to(equal(expectedValue))
+    }
+
     func testItCanUseCommonPatternsForOverrides() throws {
         let dict: [String: Any] = [
             "defaultValue": "test value",

--- a/Tests/ConfigTests/ConfigurationPropertyTests.swift
+++ b/Tests/ConfigTests/ConfigurationPropertyTests.swift
@@ -356,13 +356,6 @@ class ConfigurationPropertyTests: XCTestCase {
         expect(actualValue).to(equal(expectedValue))
     }
 
-    func testItWritesAnEmptyStringForAnEnvironmentVariableThatIsNotSet() throws {
-        let property = ConfigurationProperty<String>(key: "test", typeHint: "EnvironmentVariable", dict: ["defaultValue": "DOESNT_EXIST"])
-        let expectedValue = ##"    static let test: String = """##
-        let actualValue = try whenTheDeclarationIsWritten(for: property)
-        expect(actualValue).to(equal(expectedValue))
-    }
-
     func testItCanUseCommonPatternsForOverrides() throws {
         let dict: [String: Any] = [
             "defaultValue": "test value",


### PR DESCRIPTION
Adds the ability to specify an `EnvironmentVariable` in a config. Expected usage being something like:

```
    "secretAPIKey": {
      "type": "EnvironmentVariable",
      "defaultValue": "SECRET_API_KEY"
    }
```

The actual value will get get pulled in from an environment variable (if the named one exists) when the config is written.