### PR TITLE
Add dev mode to enable suppression of fatal errors on missing environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ The "key" will be used as a static property name in a `class` so should have a f
 - `Regex`: A regular expression pattern. Will be converted to `try! NSRegularExpression(patthen: "the value", options: [])`
 - `EncryptionKey`: A key to use to encrypt sensitive info.
 - `Encrypted`: A value that should be encrypted using the provided key
+- `EnvironmentVariable`: A named environment variable, the value of which will be obtained from the current shell environment at runtime.
+- `EncryptedEnvironmentVariable`: Encrypted version of `EnvironmentVariable` (requires `EncryptionKey` be defined).
 - `Dictionary`: A dictionary. Keys should be strings, values in the dictionary should be either string, numeric, or a new dictionary.
 - `Reference`: See [Reference Properties](#reference-properties) below.
 - Enum types. Set the `type` to the name of the enum, set the value to be the case, preceded by a `.`, so `.thing`. If you need enums from a custom module, add a string array of imports to the template section.

--- a/Sources/Config/Arguments.swift
+++ b/Sources/Config/Arguments.swift
@@ -13,6 +13,7 @@ struct Arguments {
     let configURL: URL
     let additionalExtension: String?
     let verbose: Bool
+    let developerMode: Bool
 }
 
 extension Arguments {
@@ -22,8 +23,9 @@ extension Arguments {
         case configPath = "--configPath"
         case additionalExtension = "--ext"
         case verbose = "--verbose"
+        case developerMode = "--dev"
 
-        static let all: [Option] = [.scheme, .configPath, .additionalExtension, .verbose]
+        static let all: [Option] = [.scheme, .configPath, .additionalExtension, .verbose, .developerMode]
 
         var usage: String {
             switch self {
@@ -35,6 +37,8 @@ extension Arguments {
                 return "\(rawValue)\t\t(Optional) An additional extension slug to add before .swift in the output files. Useful for .gitignore"
             case .verbose:
                 return "\(rawValue)\t\t(Optional) Should extra logging be output?"
+            case .developerMode:
+                return "\(rawValue)\t\t(Optional) Enable less strict developer mode that issues warnings on missing environment variables"
             }
         }
     }
@@ -65,6 +69,7 @@ extension Arguments {
         self.configURL = URL(fileURLWithPath: configPath)
         self.additionalExtension = argumentPairs[.additionalExtension]
         self.verbose = argumentPairs[.verbose] == "true"
+        self.developerMode = argumentPairs[.developerMode] == "true"
     }
 }
 

--- a/Sources/Config/ConfigGenerator.swift
+++ b/Sources/Config/ConfigGenerator.swift
@@ -32,7 +32,7 @@ public class ConfigGenerator {
                 throw ConfigError.badJSON
             }
             guard let template = templates.first(where: { $0.canHandle(config: config) == true }) else { throw ConfigError.noTemplate }
-            let configurationFile = try template.init(config: config, name: url.deletingPathExtension().lastPathComponent, scheme: arguments.scheme, source: url.deletingLastPathComponent())
+            let configurationFile = try template.init(config: config, name: url.deletingPathExtension().lastPathComponent, scheme: arguments.scheme, source: url.deletingLastPathComponent(), generationBehaviour: GenerationBehaviour(developerMode: arguments.developerMode))
             var swiftOutput: URL
             if let filename = configurationFile.filename {
                 swiftOutput = url.deletingLastPathComponent().appendingPathComponent(filename)

--- a/Sources/Config/ConfigurationProperty.swift
+++ b/Sources/Config/ConfigurationProperty.swift
@@ -92,7 +92,7 @@ struct ConfigurationProperty<T>: Property, AssociatedPropertyKeyProviding {
         return defaultValue
     }
 
-    func propertyDeclaration(for scheme: String, iv: IV, encryptionKey: String?, requiresNonObjCDeclarations: Bool, isPublic: Bool, instanceProperty: Bool, indentWidth: Int) -> String {
+    func propertyDeclaration(for scheme: String, iv: IV, encryptionKey: String?, requiresNonObjCDeclarations: Bool, isPublic: Bool, instanceProperty: Bool, indentWidth: Int, generationBehaviour: GenerationBehaviour) -> String {
         var template: String = ""
         if let description = description {
             template += "\(String.indent(for: indentWidth))/// \(description)\n"
@@ -107,7 +107,7 @@ struct ConfigurationProperty<T>: Property, AssociatedPropertyKeyProviding {
         let propertyValue = value(for: scheme)
         let outputValue: String
         if let type = type {
-            outputValue = type.valueDeclaration(for: propertyValue, iv: iv, key: encryptionKey)
+            outputValue = type.valueDeclaration(for: propertyValue, iv: iv, key: encryptionKey, generationBehaviour: generationBehaviour)
         } else {
             outputValue = "\(propertyValue)"
         }

--- a/Sources/Config/CustomType.swift
+++ b/Sources/Config/CustomType.swift
@@ -55,7 +55,7 @@ struct CustomProperty: Property {
         return customType.typeName
     }
 
-    func propertyDeclaration(for scheme: String, iv: IV, encryptionKey: String?, requiresNonObjCDeclarations: Bool, isPublic: Bool, instanceProperty: Bool, indentWidth: Int) -> String {
+    func propertyDeclaration(for scheme: String, iv: IV, encryptionKey: String?, requiresNonObjCDeclarations: Bool, isPublic: Bool, instanceProperty: Bool, indentWidth: Int, generationBehaviour: GenerationBehaviour) -> String {
         return template(for: description, isPublic: isPublic, instanceProperty: instanceProperty, indentWidth: indentWidth).replacingOccurrences(of: "{key}", with: key)
             .replacingOccurrences(of: "{typeName}", with: typeName)
             .replacingOccurrences(of: "{value}", with: outputValue(for: scheme, type: customType))
@@ -94,7 +94,7 @@ struct CustomPropertyArray: Property {
         return "[\(customType.typeName)]"
     }
 
-    func propertyDeclaration(for scheme: String, iv: IV, encryptionKey: String?, requiresNonObjCDeclarations: Bool, isPublic: Bool, instanceProperty: Bool, indentWidth: Int) -> String {
+    func propertyDeclaration(for scheme: String, iv: IV, encryptionKey: String?, requiresNonObjCDeclarations: Bool, isPublic: Bool, instanceProperty: Bool, indentWidth: Int, generationBehaviour: GenerationBehaviour) -> String {
         return template(for: description, isPublic: isPublic, instanceProperty: instanceProperty, indentWidth: indentWidth).replacingOccurrences(of: "{key}", with: key)
             .replacingOccurrences(of: "{typeName}", with: typeName)
             .replacingOccurrences(of: "{value}", with: outputValue(for: scheme, type: customType))
@@ -125,7 +125,7 @@ private func valueString(for placeholder: Placeholder, from dictionary: [String:
 private func valueString(for placeholder: Placeholder, from value: Any) -> String {
     guard let unusedIV = try? IV(dict: [:]) else { return "" }
     if let type = placeholder.type {
-        return type.valueDeclaration(for: value, iv: unusedIV, key: nil)
+        return type.valueDeclaration(for: value, iv: unusedIV, key: nil, generationBehaviour: GenerationBehaviour())
     } else {
         return "\(value)"
     }

--- a/Sources/Config/EnumConfiguration.swift
+++ b/Sources/Config/EnumConfiguration.swift
@@ -29,10 +29,12 @@ struct EnumConfiguration: Template {
     let type: String
 
     let properties: [String: Property]
+    let generationBehaviour: GenerationBehaviour
 
-    init(config: [String: Any], name: String, scheme: String, source: URL) throws {
+    init(config: [String: Any], name: String, scheme: String, source: URL, generationBehaviour: GenerationBehaviour = GenerationBehaviour()) throws {
         self.name = name
         self.scheme = scheme
+        self.generationBehaviour = generationBehaviour
         guard let template = config["template"] as? [String: String],
             let type = template["rawType"] else { throw EnumError.noType }
         self.type = type

--- a/Sources/Config/GenerationBehaviour.swift
+++ b/Sources/Config/GenerationBehaviour.swift
@@ -1,0 +1,18 @@
+//
+//  GenerationBehaviour.swift
+//
+//
+//  Created by drh on 22/01/2024.
+//
+
+import Foundation
+
+/// Struct for configuring configuration generation behaviour.
+struct GenerationBehaviour {
+    /// When enabled, will create warnings on generation failures rather than fatal errors.
+    let developerMode: Bool
+    
+    init(developerMode: Bool = false) {
+        self.developerMode = developerMode
+    }
+}

--- a/Sources/Config/IV.swift
+++ b/Sources/Config/IV.swift
@@ -19,7 +19,7 @@ struct IV: Property {
         hash = try dict.hashRepresentation()
     }
 
-    func propertyDeclaration(for scheme: String, iv: IV, encryptionKey: String?, requiresNonObjCDeclarations: Bool, isPublic: Bool, instanceProperty: Bool, indentWidth: Int) -> String {
+    func propertyDeclaration(for scheme: String, iv: IV, encryptionKey: String?, requiresNonObjCDeclarations: Bool, isPublic: Bool, instanceProperty: Bool, indentWidth: Int, generationBehaviour: GenerationBehaviour) -> String {
         return "\(String.indent(for: indentWidth))\(isPublic ? "public " : "")\(instanceProperty ? "" : "static ")let \(key): \(typeName) = \(byteArrayOutput(from: Array(hash.utf8)))"
     }
 }

--- a/Sources/Config/Property.swift
+++ b/Sources/Config/Property.swift
@@ -169,11 +169,6 @@ enum PropertyType: String {
         }
     }
     
-    private enum EnvResult {
-        case defined(String)
-        case undefined
-    }
-
     private func produceEnvironmentVariable(for value: String?, generationBehaviour: GenerationBehaviour) -> String {
         guard let environmentVariableName = value,
               let rawValue = getenv(environmentVariableName),

--- a/Sources/Config/ReferenceProperty.swift
+++ b/Sources/Config/ReferenceProperty.swift
@@ -39,7 +39,7 @@ struct ReferenceProperty: Property {
         return defaultValue
     }
 
-    func propertyDeclaration(for scheme: String, iv: IV, encryptionKey: String?, requiresNonObjCDeclarations: Bool, isPublic: Bool, instanceProperty: Bool, indentWidth: Int) -> String {
+    func propertyDeclaration(for scheme: String, iv: IV, encryptionKey: String?, requiresNonObjCDeclarations: Bool, isPublic: Bool, instanceProperty: Bool, indentWidth: Int, generationBehaviour: GenerationBehaviour) -> String {
         var template: String = ""
         if let description = description {
             template += "\(String.indent(for: indentWidth))/// \(description)\n"

--- a/Sources/Config/Template.swift
+++ b/Sources/Config/Template.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 protocol Template: CustomStringConvertible {
-    init(config: [String: Any], name: String, scheme: String, source: URL) throws
+    init(config: [String: Any], name: String, scheme: String, source: URL, generationBehaviour: GenerationBehaviour) throws
 
     static func canHandle(config: [String: Any]) -> Bool
 

--- a/Tests/ConfigTests/ArgumentsTests.swift
+++ b/Tests/ConfigTests/ArgumentsTests.swift
@@ -30,7 +30,15 @@ class ArgumentsTests: XCTestCase {
             "--configPath", "/config/path"
         ])
         expect(arguments.additionalExtension).to(beNil())
+    }
 
+    func testDevModeIsDisabledByDefault() throws {
+        let arguments = try Arguments(argumentList: [
+            "binary",
+            "--scheme", "test-scheme",
+            "--configPath", "/config/path"
+        ])
+        expect(arguments.developerMode).to(beFalse())
     }
 
     func testItThrowsAnExceptionWhenRequiredValuesAreNotPassed() {

--- a/Tests/ConfigTests/ConfigGeneratorTests.swift
+++ b/Tests/ConfigTests/ConfigGeneratorTests.swift
@@ -107,6 +107,7 @@ class ConfigGeneratorTests: XCTestCase {
         \(Arguments.Option.configPath.usage)
         \(Arguments.Option.additionalExtension.usage)
         \(Arguments.Option.verbose.usage)
+        \(Arguments.Option.developerMode.usage)
         """))
     }
 

--- a/Tests/ConfigTests/ConfigurationPropertyTests.swift
+++ b/Tests/ConfigTests/ConfigurationPropertyTests.swift
@@ -22,10 +22,10 @@ class ConfigurationPropertyTests: XCTestCase {
         ])
     }
 
-    func whenTheDeclarationIsWritten<T>(for configurationProperty: ConfigurationProperty<T>?, scheme: String = "any", encryptionKey: String? = nil, isPublic: Bool = false, instanceProperty: Bool = false, requiresNonObjC: Bool = false, indentWidth: Int = 0) throws -> String? {
+    func whenTheDeclarationIsWritten<T>(for configurationProperty: ConfigurationProperty<T>?, scheme: String = "any", encryptionKey: String? = nil, isPublic: Bool = false, instanceProperty: Bool = false, requiresNonObjC: Bool = false, indentWidth: Int = 0, generationBehaviour: GenerationBehaviour = GenerationBehaviour()) throws -> String? {
         let iv = try IV(dict: ["initialise": "me"])
         print("\(iv.hash)")
-        return configurationProperty?.propertyDeclaration(for: scheme, iv: iv, encryptionKey: encryptionKey, requiresNonObjCDeclarations: requiresNonObjC, isPublic: isPublic, instanceProperty: instanceProperty, indentWidth: indentWidth)
+        return configurationProperty?.propertyDeclaration(for: scheme, iv: iv, encryptionKey: encryptionKey, requiresNonObjCDeclarations: requiresNonObjC, isPublic: isPublic, instanceProperty: instanceProperty, indentWidth: indentWidth, generationBehaviour: generationBehaviour)
     }
 
     func testItCanWriteADeclarationForAStringPropertyUsingTheDefaultValue() throws {
@@ -352,6 +352,13 @@ class ConfigurationPropertyTests: XCTestCase {
         let property = ConfigurationProperty<String>(key: "test", typeHint: "EnvironmentVariable", dict: ["defaultValue": "SOMETHING"])
         let expectedValue = ##"    static let test: String = #"testValue"#"##
         let actualValue = try whenTheDeclarationIsWritten(for: property)
+        expect(actualValue).to(equal(expectedValue))
+    }
+    
+    func testItCreatesAWarningWhenAnEnvironmentVariablePropertyDoesNotExistAndDeveloperModeIsEnabled() throws {
+        let property = ConfigurationProperty<String>(key: "test", typeHint: "EnvironmentVariable", dict: ["defaultValue": "DOESNT_EXIST"])
+        let expectedValue = ##"    static let test: String = #"Environment variable DOESNT_EXIST was not defined at runtime"#"##
+        let actualValue = try whenTheDeclarationIsWritten(for: property, generationBehaviour: GenerationBehaviour(developerMode: true))
         expect(actualValue).to(equal(expectedValue))
     }
 

--- a/Tests/ConfigTests/CustomPropertyTests.swift
+++ b/Tests/ConfigTests/CustomPropertyTests.swift
@@ -33,7 +33,7 @@ class CustomPropertyTests: XCTestCase {
             /// A description
             static let test: CustomType = CustomType(oneThing: firstValue, secondThing: secondValue)
         """
-        expect(property.propertyDeclaration(for: "any", iv: try IV(dict: [:]), encryptionKey: nil, requiresNonObjCDeclarations: false, isPublic: false, instanceProperty: false, indentWidth: 0)).to(equal(expectedValue))
+        expect(property.propertyDeclaration(for: "any", iv: try IV(dict: [:]), encryptionKey: nil, requiresNonObjCDeclarations: false, isPublic: false, instanceProperty: false, indentWidth: 0, generationBehaviour: GenerationBehaviour())).to(equal(expectedValue))
     }
 
     func testItOutputAPublicPropertyDeclarationCorrectly() throws {
@@ -42,7 +42,7 @@ class CustomPropertyTests: XCTestCase {
             /// A description
             public let test: CustomType = CustomType(oneThing: firstValue, secondThing: secondValue)
         """
-        expect(property.propertyDeclaration(for: "any", iv: try IV(dict: [:]), encryptionKey: nil, requiresNonObjCDeclarations: false, isPublic: true, instanceProperty: true, indentWidth: 0)).to(equal(expectedValue))
+        expect(property.propertyDeclaration(for: "any", iv: try IV(dict: [:]), encryptionKey: nil, requiresNonObjCDeclarations: false, isPublic: true, instanceProperty: true, indentWidth: 0, generationBehaviour: GenerationBehaviour())).to(equal(expectedValue))
     }
 
     func testItOutputAPropertyDeclarationCorrectlyForAnOverriddenScheme() throws {
@@ -51,7 +51,7 @@ class CustomPropertyTests: XCTestCase {
             /// A description
             public static let test: CustomType = CustomType(oneThing: firstOverriddenValue, secondThing: secondOverriddenValue)
         """
-        expect(property.propertyDeclaration(for: "override", iv: try IV(dict: [:]), encryptionKey: nil, requiresNonObjCDeclarations: false, isPublic: true, instanceProperty: false, indentWidth: 0)).to(equal(expectedValue))
+        expect(property.propertyDeclaration(for: "override", iv: try IV(dict: [:]), encryptionKey: nil, requiresNonObjCDeclarations: false, isPublic: true, instanceProperty: false, indentWidth: 0, generationBehaviour: GenerationBehaviour())).to(equal(expectedValue))
     }
 
     func testItOutputsAPropertyForAnInitialiserWithoutPlaceholders() throws {
@@ -63,7 +63,7 @@ class CustomPropertyTests: XCTestCase {
             /// A description
             public static let test: CustomType = CustomType()
         """
-        expect(property.propertyDeclaration(for: "any", iv: try IV(dict: [:]), encryptionKey: nil, requiresNonObjCDeclarations: false, isPublic: true, instanceProperty: false, indentWidth: 0)).to(equal(expectedValue))
+        expect(property.propertyDeclaration(for: "any", iv: try IV(dict: [:]), encryptionKey: nil, requiresNonObjCDeclarations: false, isPublic: true, instanceProperty: false, indentWidth: 0, generationBehaviour: GenerationBehaviour())).to(equal(expectedValue))
     }
 
     func testItOutputsAPropertyForASinglePlaceholder() {
@@ -75,7 +75,7 @@ class CustomPropertyTests: XCTestCase {
             /// A description
             public static let test: CustomType = CustomType(thingy: test default value)
         """
-        expect(property.propertyDeclaration(for: "any", iv: try IV(dict: [:]), encryptionKey: nil, requiresNonObjCDeclarations: false, isPublic: true, instanceProperty: false, indentWidth: 0)).to(equal(expectedValue))
+        expect(property.propertyDeclaration(for: "any", iv: try IV(dict: [:]), encryptionKey: nil, requiresNonObjCDeclarations: false, isPublic: true, instanceProperty: false, indentWidth: 0, generationBehaviour: GenerationBehaviour())).to(equal(expectedValue))
     }
 
     func testItOutputsAPropertyForASingleNamedPlaceholder() {
@@ -87,7 +87,7 @@ class CustomPropertyTests: XCTestCase {
             /// A description
             public static let test: CustomType = CustomType(thingy: #"firstValue"#)
         """
-        expect(property.propertyDeclaration(for: "any", iv: try IV(dict: [:]), encryptionKey: nil, requiresNonObjCDeclarations: false, isPublic: true, instanceProperty: false, indentWidth: 0)).to(equal(expectedValue))
+        expect(property.propertyDeclaration(for: "any", iv: try IV(dict: [:]), encryptionKey: nil, requiresNonObjCDeclarations: false, isPublic: true, instanceProperty: false, indentWidth: 0, generationBehaviour: GenerationBehaviour())).to(equal(expectedValue))
     }
 
     func testItOutputsAPropertyForATypeWithTypeAnnotations() {
@@ -96,7 +96,7 @@ class CustomPropertyTests: XCTestCase {
             /// A description
             public static let test: CustomType = CustomType(oneThing: #"firstValue"#, secondThing: true)
         """
-        expect(property.propertyDeclaration(for: "any", iv: try IV(dict: [:]), encryptionKey: nil, requiresNonObjCDeclarations: false, isPublic: true, instanceProperty: false, indentWidth: 0)).to(equal(expectedValue))
+        expect(property.propertyDeclaration(for: "any", iv: try IV(dict: [:]), encryptionKey: nil, requiresNonObjCDeclarations: false, isPublic: true, instanceProperty: false, indentWidth: 0, generationBehaviour: GenerationBehaviour())).to(equal(expectedValue))
     }
 
     func testItOutputsAStringWithEscapedSlashesCorrectly() {
@@ -104,7 +104,7 @@ class CustomPropertyTests: XCTestCase {
         let expectedValue = """
             public static let test: NSRegularExpression = try! NSRegularExpression(expression: #"^.*\\@.*\\.[a-zA-Z]{2,3}$"#, options: [])
         """
-        expect(property.propertyDeclaration(for: "any", iv: try IV(dict: [:]), encryptionKey: nil, requiresNonObjCDeclarations: false, isPublic: true, instanceProperty: false, indentWidth: 0)).to(equal(expectedValue))
+        expect(property.propertyDeclaration(for: "any", iv: try IV(dict: [:]), encryptionKey: nil, requiresNonObjCDeclarations: false, isPublic: true, instanceProperty: false, indentWidth: 0, generationBehaviour: GenerationBehaviour())).to(equal(expectedValue))
     }
 
     func testItOutputsAStringWithEscapedSlashesCorrectlyForSingleValue() {
@@ -112,7 +112,7 @@ class CustomPropertyTests: XCTestCase {
         let expectedValue = """
             public static let test: NSRegularExpression = try! NSRegularExpression(expression: #"^.*\\@.*\\.[a-zA-Z]{2,3}$"#, options: [])
         """
-        expect(property.propertyDeclaration(for: "any", iv: try IV(dict: [:]), encryptionKey: nil, requiresNonObjCDeclarations: false, isPublic: true, instanceProperty: false, indentWidth: 0)).to(equal(expectedValue))
+        expect(property.propertyDeclaration(for: "any", iv: try IV(dict: [:]), encryptionKey: nil, requiresNonObjCDeclarations: false, isPublic: true, instanceProperty: false, indentWidth: 0, generationBehaviour: GenerationBehaviour())).to(equal(expectedValue))
     }
 }
 
@@ -139,7 +139,7 @@ class CustomPropertyArrayTests: XCTestCase {
             /// A description
             public static let test: [CustomType] = [CustomType(oneThing: #"firstValue"#, secondThing: true)]
         """
-        expect(property.propertyDeclaration(for: "any", iv: try IV(dict: [:]), encryptionKey: nil, requiresNonObjCDeclarations: false, isPublic: true, instanceProperty: false, indentWidth: 0)).to(equal(expectedValue))
+        expect(property.propertyDeclaration(for: "any", iv: try IV(dict: [:]), encryptionKey: nil, requiresNonObjCDeclarations: false, isPublic: true, instanceProperty: false, indentWidth: 0, generationBehaviour: GenerationBehaviour())).to(equal(expectedValue))
     }
 
     func testItOutputsAPropertyForAnOverriddenScheme() {
@@ -148,7 +148,7 @@ class CustomPropertyArrayTests: XCTestCase {
             /// A description
             public static let test: [CustomType] = [CustomType(oneThing: #"firstOverriddenValue"#, secondThing: false)]
         """
-        expect(property.propertyDeclaration(for: "override", iv: try IV(dict: [:]), encryptionKey: nil, requiresNonObjCDeclarations: false, isPublic: true, instanceProperty: false, indentWidth: 0)).to(equal(expectedValue))
+        expect(property.propertyDeclaration(for: "override", iv: try IV(dict: [:]), encryptionKey: nil, requiresNonObjCDeclarations: false, isPublic: true, instanceProperty: false, indentWidth: 0, generationBehaviour: GenerationBehaviour())).to(equal(expectedValue))
     }
 }
 

--- a/Tests/ConfigTests/IVTests.swift
+++ b/Tests/ConfigTests/IVTests.swift
@@ -14,7 +14,7 @@ class IVTests: XCTestCase {
     func testItWritesAPropertyDeclarationCorrectly() throws {
         let iv = try IV(dict: ["hello": "world"])
         let expectedByteArray = "[UInt8(102), UInt8(98), UInt8(99), UInt8(50), UInt8(52), UInt8(98), UInt8(99), UInt8(99), UInt8(55), UInt8(97), UInt8(49), UInt8(55), UInt8(57), UInt8(52), UInt8(55), UInt8(53), UInt8(56), UInt8(102), UInt8(99), UInt8(49), UInt8(51), UInt8(50), UInt8(55), UInt8(102), UInt8(99), UInt8(102), UInt8(101), UInt8(98), UInt8(100), UInt8(97), UInt8(102), UInt8(54)]"
-        expect(iv.propertyDeclaration(for: "", iv: iv, encryptionKey: nil, requiresNonObjCDeclarations: false, isPublic: false, instanceProperty: false, indentWidth: 0)).to(equal("    static let encryptionKeyIV: [UInt8] = \(expectedByteArray)"))
-        expect(iv.propertyDeclaration(for: "", iv: iv, encryptionKey: nil, requiresNonObjCDeclarations: false, isPublic: true, instanceProperty: true, indentWidth: 0)).to(equal("    public let encryptionKeyIV: [UInt8] = \(expectedByteArray)"))
+        expect(iv.propertyDeclaration(for: "", iv: iv, encryptionKey: nil, requiresNonObjCDeclarations: false, isPublic: false, instanceProperty: false, indentWidth: 0, generationBehaviour: GenerationBehaviour())).to(equal("    static let encryptionKeyIV: [UInt8] = \(expectedByteArray)"))
+        expect(iv.propertyDeclaration(for: "", iv: iv, encryptionKey: nil, requiresNonObjCDeclarations: false, isPublic: true, instanceProperty: true, indentWidth: 0, generationBehaviour: GenerationBehaviour())).to(equal("    public let encryptionKeyIV: [UInt8] = \(expectedByteArray)"))
     }
 }

--- a/Tests/ConfigTests/ReferencePropertyTests.swift
+++ b/Tests/ConfigTests/ReferencePropertyTests.swift
@@ -24,7 +24,7 @@ class ReferencePropertyTests: XCTestCase {
     func whenTheDeclarationIsWritten(for property: ReferenceProperty?, scheme: String = "any", encryptionKey: String? = nil, isPublic: Bool = false, instanceProperty: Bool = false, requiresNonObjC: Bool = false, indentWidth: Int = 0) throws -> String? {
         let iv = try IV(dict: ["initialise": "me"])
         print("\(iv.hash)")
-        return property?.propertyDeclaration(for: scheme, iv: iv, encryptionKey: encryptionKey, requiresNonObjCDeclarations: requiresNonObjC, isPublic: isPublic, instanceProperty: instanceProperty, indentWidth: indentWidth)
+        return property?.propertyDeclaration(for: scheme, iv: iv, encryptionKey: encryptionKey, requiresNonObjCDeclarations: requiresNonObjC, isPublic: isPublic, instanceProperty: instanceProperty, indentWidth: indentWidth, generationBehaviour: GenerationBehaviour())
     }
 
     func testItCanWriteADeclarationForAStringPropertyUsingTheDefaultValue() throws {

--- a/Tests/ConfigTests/TemplateTests.swift
+++ b/Tests/ConfigTests/TemplateTests.swift
@@ -12,13 +12,13 @@ import XCTest
 
 class TemplateTests: XCTestCase {
     func testThereIsADefaultFilename() throws {
-        let template = try TestTemplate(config: [:], name: "", scheme: "", source: URL(fileURLWithPath: "/"))
+        let template = try TestTemplate(config: [:], name: "", scheme: "", source: URL(fileURLWithPath: "/"), generationBehaviour: GenerationBehaviour())
         expect(template.filename).to(beNil())
     }
 }
 
 struct TestTemplate: Template {
-    init(config: [String : Any], name: String, scheme: String, source: URL) throws {
+    init(config: [String : Any], name: String, scheme: String, source: URL, generationBehaviour: GenerationBehaviour) throws {
     }
 
     static func canHandle(config: [String : Any]) -> Bool {


### PR DESCRIPTION
Adds a `--dev` command line option, which can be used to avoid fatal errors during generation when environment variables are undefined in the current environment.

This can be useful on development machines so that addition of environment variables to the config by other developers does not break your current build.